### PR TITLE
update: User can run vic in his arduino

### DIFF
--- a/src/vic-exec.c
+++ b/src/vic-exec.c
@@ -9,7 +9,7 @@
 
 char *vic_args_s = NULL;
 
-int8_t vic_exec(char *input)
+uint8_t vic_exec(char *input)
 {
     uint8_t start = 0, end;
     /* find start of func name */
@@ -36,7 +36,7 @@ int8_t vic_exec(char *input)
     vic_args_s = input + end + 1;
     char *command = input + start;
 
-    int8_t error = vic_fn_call(command);
+    uint8_t error = vic_fn_call(command);
 
     vic_print_err(error);
 

--- a/src/vic-funcs.c
+++ b/src/vic-funcs.c
@@ -19,7 +19,7 @@ void vic_funcs_clear(void)
     vic_funcs_len = VIC_INTERN_FUNCS_COUNT;
 }
 
-int8_t vic_fn_add(const char *raw_name, void (*p_func)(void))
+uint8_t vic_fn_add(const char *raw_name, void (*p_func)(void))
 {
     char name[VIC_FUNC_NAME_LEN+1] = {'\0'};
     strncpy(name, raw_name, VIC_FUNC_NAME_LEN);
@@ -49,7 +49,7 @@ int8_t vic_fn_add(const char *raw_name, void (*p_func)(void))
     return VIC_ERR_NO;
 }
 
-int8_t vic_fn_call(const char *raw_name)
+uint8_t vic_fn_call(const char *raw_name)
 {
     char name[VIC_FUNC_NAME_LEN + 1] = {'\0'};
     strncpy(name, raw_name, VIC_FUNC_NAME_LEN);
@@ -65,7 +65,7 @@ int8_t vic_fn_call(const char *raw_name)
     return VIC_ERR_INVALID_NAME;
 }
 
-int8_t vic_fn_rm(const char *raw_name)
+uint8_t vic_fn_rm(const char *raw_name)
 {
     char name[VIC_FUNC_NAME_LEN + 1] = {'\0'};
     strncpy(name, raw_name, VIC_FUNC_NAME_LEN);

--- a/src/vic-serial.c
+++ b/src/vic-serial.c
@@ -19,7 +19,7 @@ void vic_out(char c)
     }
 }
 
-void vic_print(char *s)
+void vic_print(const char *s)
 {
     if (vic_output_func != NULL) {
         while (*s != '\0') {
@@ -27,6 +27,14 @@ void vic_print(char *s)
             s++;
         }
     }
+}
+
+void vic_print_err(uint8_t id)
+{
+    static char buffer[VIC_BUFFER_SIZE + 1];
+    strncpy_P(buffer, (char*)pgm_read_word(&vic_err_msg[id]), VIC_BUFFER_SIZE);
+    buffer[VIC_BUFFER_SIZE] = '\0';
+    vic_print(buffer);
 }
 
 void vic_buffer_clear(void)

--- a/src/vic-stdlib.c
+++ b/src/vic-stdlib.c
@@ -20,7 +20,7 @@ void vic_set(void)
         return;
     }
 
-    int8_t error = vic_var_set(var_name, var_val);
+    uint8_t error = vic_var_set(var_name, var_val);
 
     vic_print_err(error);
 }
@@ -36,7 +36,7 @@ void vic_get(void)
     }
 
     char *value = NULL;
-    int8_t error = vic_var_get(var_name, &value);
+    uint8_t error = vic_var_get(var_name, &value);
 
     vic_print_err(error);
     if (value != NULL) {

--- a/src/vic-var.c
+++ b/src/vic-var.c
@@ -13,7 +13,7 @@ void vic_vars_clear(void)
     vic_vars_len = 0;
 }
 
-int8_t vic_var_set(const char *raw_name, const char *value)
+uint8_t vic_var_set(const char *raw_name, const char *value)
 {
     char name[VIC_VAR_NAME_LEN+1] = {'\0'};
 
@@ -25,7 +25,7 @@ int8_t vic_var_set(const char *raw_name, const char *value)
         /* set value to variable when found */
         if (strcmp(name, vic_vars[i].name) == 0) {
             strncpy(vic_vars[i].value, value, VIC_VAR_VAL_LEN);
-            vic_var_set_bind_val(&vic_vars[i]);
+            vic_var_update_bind_val(&vic_vars[i]);
             return VIC_ERR_NO;
         }
     }
@@ -49,7 +49,7 @@ int8_t vic_var_set(const char *raw_name, const char *value)
     return VIC_ERR_NO;
 }
 
-int8_t vic_var_get(const char *raw_name, char **value_out)
+uint8_t vic_var_get(const char *raw_name, char **value_out)
 {
     char name[VIC_VAR_NAME_LEN+1] = {'\0'};
     strncpy(name, raw_name, VIC_VAR_NAME_LEN);
@@ -58,6 +58,7 @@ int8_t vic_var_get(const char *raw_name, char **value_out)
     for (i = 0; i < vic_vars_len; i++) {
         if (strcmp(name, vic_vars[i].name) == 0) {
             /* found variable with that name */
+            vic_var_update_value(&vic_vars[i]);
             *value_out = (char *)vic_vars[i].value;
             return VIC_ERR_NO;
         }
@@ -66,7 +67,7 @@ int8_t vic_var_get(const char *raw_name, char **value_out)
     return VIC_ERR_INVALID_NAME;
 }
 
-int8_t vic_var_bind(const char *raw_name, void *bind_val, const uint8_t type)
+uint8_t vic_var_bind(const char *raw_name, void *bind_val, const uint8_t type)
 {
     char name[VIC_VAR_NAME_LEN+1] = {'\0'};
     strncpy(name, raw_name, VIC_VAR_NAME_LEN);
@@ -77,7 +78,7 @@ int8_t vic_var_bind(const char *raw_name, void *bind_val, const uint8_t type)
             /* found variable with that name */
             vic_vars[i].bind_val = bind_val;
             vic_vars[i].type = type;
-            vic_var_set_bind_val(&vic_vars[i]);
+            vic_var_update_bind_val(&vic_vars[i]);
             return VIC_ERR_NO;
         }
     }
@@ -85,7 +86,7 @@ int8_t vic_var_bind(const char *raw_name, void *bind_val, const uint8_t type)
     return VIC_ERR_INVALID_NAME;
 }
 
-void vic_var_set_bind_val(struct vic_var_t *vic_var)
+void vic_var_update_bind_val(struct vic_var_t *vic_var)
 {
     if (vic_var->bind_val == NULL) {
         return;
@@ -113,6 +114,54 @@ void vic_var_set_bind_val(struct vic_var_t *vic_var)
         */
         case VIC_VAR_FLOAT :
             *((float *)vic_var->bind_val) = (float)atof(vic_var->value);
+            return;
+    }
+}
+
+void vic_var_update_value(struct vic_var_t *vic_var)
+{
+    if (vic_var->bind_val == NULL) {
+        return;
+    }
+#ifdef ARDUINO
+    float f; /* see VIC_VAR_FLOAT case */
+#endif
+    switch (vic_var->type) {
+        case VIC_VAR_INT8 :
+            snprintf(vic_var->value, VIC_VAR_VAL_LEN, "%d",
+                        *((int8_t *)vic_var->bind_val));
+            return;
+        case VIC_VAR_UINT8 :
+            snprintf(vic_var->value, VIC_VAR_VAL_LEN, "%u",
+                        *((uint8_t *)vic_var->bind_val));
+            return;
+        case VIC_VAR_INT16 :
+            snprintf(vic_var->value, VIC_VAR_VAL_LEN, "%d",
+                        *((int16_t *)vic_var->bind_val));
+            return;
+        case VIC_VAR_UINT16 :
+            snprintf(vic_var->value, VIC_VAR_VAL_LEN, "%u",
+                        *((uint16_t *)vic_var->bind_val));
+            return;
+        /*
+        case VIC_VAR_INT32 :
+            snprintf(vic_var->value, VIC_VAR_VAL_LEN, "%d",
+                        *((int32_t *)vic_var->bind_val));
+            return;
+        case VIC_VAR_UINT32 :
+            snprintf(vic_var->value, VIC_VAR_VAL_LEN, "%u",
+                        *((uint32_t *)vic_var->bind_val));
+            return;
+        */
+        case VIC_VAR_FLOAT :
+#ifdef ARDUINO
+            f = *((float *)vic_var->bind_val);
+            snprintf(vic_var->value, VIC_VAR_VAL_LEN, "%d.%02d",
+                    (int)f, abs((int)((f - (int)f) * 100)));
+#else
+            snprintf(vic_var->value, VIC_VAR_VAL_LEN, "%f",
+                        *((float *)vic_var->bind_val));
+#endif
             return;
     }
 }

--- a/src/vic-var.c
+++ b/src/vic-var.c
@@ -154,7 +154,7 @@ void vic_var_update_value(struct vic_var_t *vic_var)
             return;
         */
         case VIC_VAR_FLOAT :
-#ifdef ARDUINO
+#ifdef ARDUINO /* snprintf %f doesn't work with arduino */
             f = *((float *)vic_var->bind_val);
             snprintf(vic_var->value, VIC_VAR_VAL_LEN, "%d.%02d",
                     (int)f, abs((int)((f - (int)f) * 100)));

--- a/src/vic-var.h
+++ b/src/vic-var.h
@@ -11,7 +11,10 @@ struct vic_var_t {
     uint8_t type;
 };
 
-void vic_var_set_bind_val(struct vic_var_t *vic_var);
+/* sets value to bind_val */
+void vic_var_update_bind_val(struct vic_var_t *vic_var);
+/* sets bind_val to value */
+void vic_var_update_value(struct vic_var_t *vic_var);
 
 #endif
 

--- a/src/vic.c
+++ b/src/vic.c
@@ -1,18 +1,22 @@
 #include "vic.h"
 
-char *vic_err_msg[] = {
-    /* VIC_ERR_NO */
-    "",
+/* VIC_ERR_NO */
+const char _err_msg_0[] PROGMEM = "";
 
-    /* VIC_ERR_INSUFFICIENT_SPACE */
-    "ERROR: No memory for new variable or function\n",
+/* VIC_ERR_INSUFFICIENT_SPACE */
+const char _err_msg_1[] PROGMEM = \
+    "ERROR: No memory for new variable or function\n";
 
-    /* VIC_ERR_INVALID_NAME */
-    "ERROR: Invalid name\n",
+/* VIC_ERR_INVALID_NAME */
+const char _err_msg_2[] PROGMEM = \
+    "ERROR: Invalid name\n";
 
-    /* VIC_ERR_INVALID_ARGS */
-    "ERROR: Arguments are of invalid type or there is wrong count of them\n"
-};
+/* VIC_ERR_INVALID_ARGS */
+const char _err_msg_3[] PROGMEM = \
+    "ERROR: Arguments are of invalid type or there is wrong count of them\n";
+
+const char * const vic_err_msg[] PROGMEM = {_err_msg_0, _err_msg_1,
+    _err_msg_2, _err_msg_3};
 
 void vic_init()
 {

--- a/src/vic.c
+++ b/src/vic.c
@@ -15,8 +15,12 @@ const char _err_msg_2[] PROGMEM = \
 const char _err_msg_3[] PROGMEM = \
     "ERROR: Arguments are of invalid type or there is wrong count of them\n";
 
-const char * const vic_err_msg[] PROGMEM = {_err_msg_0, _err_msg_1,
-    _err_msg_2, _err_msg_3};
+const char * const vic_err_msg[] PROGMEM = {
+    _err_msg_0,
+    _err_msg_1,
+    _err_msg_2,
+    _err_msg_3
+};
 
 void vic_init()
 {

--- a/src/vic.h
+++ b/src/vic.h
@@ -30,7 +30,7 @@
 #define VIC_FUNCS_COUNT 8
 #define VIC_VARS_COUNT 8
 
-#elif defined(__AVR_ATmega328P__) || defined(__AVR_ATmega32U4__) /* 2,2.5 kB */
+#elif defined(__AVR_ATmega328P__) || defined(__AVR_ATmega32U4__)/* 2, 2.5 kB */
 
 #define VIC_FUNCS_COUNT 16
 #define VIC_VARS_COUNT 16

--- a/src/vic.h
+++ b/src/vic.h
@@ -7,17 +7,55 @@
 #include <stdio.h>
 #include <stdint.h>
 
+
+#ifdef ARDUINO
+
+#include <avr/pgmspace.h>
+
+#else
+
+#define PROGMEM
+#define pgm_read_word *
+#define strncpy_P strncpy
+
+#endif /* arduino */
+
 #define vic_args(format, ...) (sscanf(vic_args_s, (format), __VA_ARGS__))
 #define VIC_XSTR(s) VIC_STR(s)
 #define VIC_STR(s) #s
-
 #define VIC_PS1 "+> "
-#define VIC_BUFFER_SIZE 128
+
+#if defined(__AVR_ATmega168__) /* 1 kB */
+
+#define VIC_FUNCS_COUNT 8
+#define VIC_VARS_COUNT 8
+
+#elif defined(__AVR_ATmega328P__) || defined(__AVR_ATmega32U4__) /* 2,2.5 kB */
+
+#define VIC_FUNCS_COUNT 16
+#define VIC_VARS_COUNT 16
+
+#elif defined(__AVR_ATmega1280__) /* 4 kB */
+
+#define VIC_FUNCS_COUNT 32
+#define VIC_VARS_COUNT 32
+
+#elif defined(__AVR_ATmega2560__) /* 8 kB */
+
 #define VIC_FUNCS_COUNT 64
-#define VIC_FUNC_NAME_LEN 6
 #define VIC_VARS_COUNT 64
-#define VIC_VAR_NAME_LEN 6
-#define VIC_VAR_VAL_LEN 10
+
+#else
+
+#define VIC_FUNCS_COUNT 64
+#define VIC_VARS_COUNT 64
+
+#endif
+
+#define VIC_BUFFER_SIZE 128
+#define VIC_FUNC_NAME_LEN 8
+#define VIC_VAR_NAME_LEN 8
+#define VIC_VAR_VAL_LEN 16
 
 #define VIC_VAR_NONE 0x00
 #define VIC_VAR_INT8 0x01
@@ -39,35 +77,35 @@
 extern char vic_buffer[VIC_BUFFER_SIZE + 1];
 extern uint8_t vic_buffer_len;
 
-#define vic_print_err(id) vic_print(vic_err_msg[id])
 #define vic_println(s) do { vic_print(s); vic_out('\n'); } while(0)
 
 void vic_out(char c);
-void vic_print(char *s);
+void vic_print(const char *s);
+void vic_print_err(uint8_t id);
 
 void vic_buffer_append(char i);
 void vic_process(char input);
 void vic_output_set(void (*output_func)(char));
 
 /* vic-funcs.c */
-int8_t vic_fn_add(const char *raw_name, void (*p_func)(void));
-int8_t vic_fn_call(const char *raw_name);
-int8_t vic_fn_rm(const char *raw_name);
+uint8_t vic_fn_add(const char *raw_name, void (*p_func)(void));
+uint8_t vic_fn_call(const char *raw_name);
+uint8_t vic_fn_rm(const char *raw_name);
 void vic_funcs_clear(void);
 
 /* vic-var.c */
-int8_t vic_var_set(const char *raw_name, const char *value);
-int8_t vic_var_get(const char *raw_name, char **value_out);
-int8_t vic_var_bind(const char *raw_name, void *bind_val, const uint8_t type);
+uint8_t vic_var_set(const char *raw_name, const char *value);
+uint8_t vic_var_get(const char *raw_name, char **value_out);
+uint8_t vic_var_bind(const char *raw_name, void *bind_val, const uint8_t type);
 void vic_vars_clear(void);
 
 /* vic-exec.c */
 extern char *vic_args_s;
 
-int8_t vic_exec(char *line);
+uint8_t vic_exec(char *line);
 
 /* vic.c */
-extern char *vic_err_msg[];
+extern const char * const vic_err_msg[] PROGMEM;
 
 void vic_init();
 

--- a/tests/arduino/arduino.ino
+++ b/tests/arduino/arduino.ino
@@ -48,12 +48,24 @@ void setup()
 
     vic_var_set("state", "0");
     vic_var_bind("state", &led_state, VIC_VAR_UINT8);
+
+    Serial.println(F("Try to use these commands: (type them and hit enter)"));
+    Serial.println(F("\ton\n\toff"));
+    Serial.println(F("\tled on\n\tled off"));
+    Serial.println(F("\tset state 1\n\tset state 0"));
+    Serial.println(F("and see LED attached to pin 13"));
+
+    Serial.println(F(VIC_PS1));
 }
 
 void loop()
 {
     if (Serial.available() > 0) {
-        vic_process((char)Serial.read());
+        char c = Serial.read();
+        vic_process(c);
+        if (c == '\n') {
+            Serial.println(F(VIC_PS1));
+        }
     }
 
     digitalWrite(13, led_state);

--- a/tests/arduino/arduino.ino
+++ b/tests/arduino/arduino.ino
@@ -4,32 +4,50 @@
 MAKE SURE YOU HAVE SET '\n' LINE ENDINGS
 ***************************************/
 
+uint8_t led_state;
+
 void set_led(void)
 {
-    int status;
-    if (vic_args("%d", &status) == 1) {
-        digitalWrite(13, status);
+    char status[5];
+    if (vic_args("%3s", &status) == 1) {
+        if (strcmp(status, "on") == 0) {
+            led_state = 1;
+        } else if (strcmp(status, "off") == 0) {
+            led_state = 0;
+        }
     }
 }
 
 void led_on(void)
 {
-    digitalWrite(13, HIGH);
+    led_state = 1;
 }
 
 void led_off(void)
 {
-    digitalWrite(13, LOW);
+    led_state = 0;
 }
+
+void serial_print(char c)
+{
+    Serial.print(c);
+}
+
+float test = 0;
 
 void setup()
 {
     Serial.begin(115200);
     pinMode(13, OUTPUT);
 
+    vic_output_set(serial_print);
+
     vic_fn_add("on", led_on);
     vic_fn_add("off", led_off);
-    vic_fn_add("set", set_led);
+    vic_fn_add("led", set_led);
+
+    vic_var_set("state", "0");
+    vic_var_bind("state", &led_state, VIC_VAR_UINT8);
 }
 
 void loop()
@@ -37,6 +55,8 @@ void loop()
     if (Serial.available() > 0) {
         vic_process((char)Serial.read());
     }
+
+    digitalWrite(13, led_state);
 }
 
 /* vim: set tabstop=4:softtabstop=4:shiftwidth=4:expandtabs */

--- a/tests/test-vic-exec.c
+++ b/tests/test-vic-exec.c
@@ -119,7 +119,7 @@ static char * test_exec_set(void)
         "set very_long_variable_name   very_long_variable_value \n",
         "  set age 7 \n"
     };
-    char *out[] = {
+    const char *out[] = {
         vic_err_msg[VIC_ERR_INVALID_ARGS],
         vic_err_msg[VIC_ERR_INVALID_ARGS],
         vic_err_msg[VIC_ERR_NO],
@@ -166,7 +166,7 @@ static char *test_exec_set_get(void)
         "set too_long_var_name value\n",
         "get too_long_var_name\n"
     };
-    char *out[] = {
+    const char *out[] = {
         vic_err_msg[VIC_ERR_NO],
         vic_err_msg[VIC_ERR_NO],
         vic_err_msg[VIC_ERR_INVALID_ARGS],


### PR DESCRIPTION
* reduced size of SRAM used by vic
    * using PROGMEM for error messages
    * setting vic-vars and vic-funcs count according to type of arduino board
* Added function to set vic-var's value from it's bind_value
    * value is intended to be string representation of bind_value
* Changed arduino test-example - led_state can be set by:
    * set state 1/0     // changing vic-var
    * led on/off        // vic-func with parameter
    * on/off            // simple vic-func
* Changed data type of errors from int8_t to uint8_t (it is usually used
  as index to array vic_err_msg)

Signed-off-by: VARGAC <simon.varga123@gmail.com>